### PR TITLE
Switch PullRequestHandler to use pull_request trigger

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -2,5 +2,6 @@
   "type": "PTE",
   "templateUrl": "https://github.com/freddydk/AL-Go@internaltemplate",
   "templateSha": "7eccfda0c99c3ae771fa201bb6ad32e89352aa63",
-  "GhTokenWorkflowSecretName": "GhAppTokenWorkflow"
+  "GhTokenWorkflowSecretName": "GhAppTokenWorkflow",
+  "PullRequestTrigger": "pull_request"
 }

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -1,7 +1,7 @@
 name: 'Pull Request Build'
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ 'main' ]
 
 concurrency:


### PR DESCRIPTION
This PR switches the PullRequestHandler workflow to use the pull_request trigger instead of pull_request_target.

Changes:
- Added PullRequestTrigger setting to AL-Go-Settings.json
- Updated PullRequestHandler.yaml trigger